### PR TITLE
Updated accounts to use mnemonic in PrecompiledToken

### DIFF
--- a/precompiled-token/truffle-config.js
+++ b/precompiled-token/truffle-config.js
@@ -22,10 +22,11 @@ const HDWalletProvider = require('@truffle/hdwallet-provider');
 //
 // const fs = require('fs');
 // const mnemonic = fs.readFileSync(".secret").toString().trim();
+const mnemonicPhrase = 'fox sight canyon orphan hotel grow hedgehog build bless august weather swarm';
 
 const mandalaConfig = (endpointUrl) => ({
   provider: () =>
-    new HDWalletProvider(['0xa872f6cbd25a0e04a08b1e21098017a9e6194d101d75e13111f71410c59cd57f'], endpointUrl),
+    new HDWalletProvider(mnemonicPhrase, endpointUrl),
   network_id: 595,
   gasPrice: 200786445289, // storage_limit = 64001, validUntil = 360001, gasLimit = 10000000
   gas: 42032000,


### PR DESCRIPTION
Updated accounts in PrecompiledToken truffle config to use the mnemonic
in stead of the private key.