### PR TITLE
make version compatible

### DIFF
--- a/DEX/package.json
+++ b/DEX/package.json
@@ -11,7 +11,7 @@
     "@acala-network/contracts": "^4.0.0",
     "@openzeppelin/contracts": "^4.4.0",
     "@truffle/hdwallet-provider": "^1.6.0",
-    "ethers": "~5.4.7",
+    "ethers": "~5.5.4",
     "truffle-assertions": "^0.9.2"
   },
   "scripts": {

--- a/DEX/package.json
+++ b/DEX/package.json
@@ -9,9 +9,9 @@
   },
   "devDependencies": {
     "@acala-network/contracts": "^4.0.0",
-    "@openzeppelin/contracts": "^4.4.1",
+    "@openzeppelin/contracts": "^4.4.0",
     "@truffle/hdwallet-provider": "^1.6.0",
-    "ethers": "^5.5.3",
+    "ethers": "~5.4.7",
     "truffle-assertions": "^0.9.2"
   },
   "scripts": {

--- a/precompiled-token/package.json
+++ b/precompiled-token/package.json
@@ -11,7 +11,7 @@
     "@acala-network/contracts": "^4.0.0",
     "@openzeppelin/contracts": "^4.4.0",
     "@truffle/hdwallet-provider": "^1.6.0",
-    "ethers": "~5.4.7",
+    "ethers": "~5.5.4",
     "truffle-assertions": "^0.9.2"
   },
   "scripts": {

--- a/precompiled-token/package.json
+++ b/precompiled-token/package.json
@@ -9,9 +9,9 @@
   },
   "devDependencies": {
     "@acala-network/contracts": "^4.0.0",
-    "@openzeppelin/contracts": "^4.4.1",
+    "@openzeppelin/contracts": "^4.4.0",
     "@truffle/hdwallet-provider": "^1.6.0",
-    "ethers": "^5.5.3",
+    "ethers": "~5.4.7",
     "truffle-assertions": "^0.9.2"
   },
   "scripts": {


### PR DESCRIPTION
this will make package version compatible with other truffle tutorials, and when `rush update` from bodhi the package manager won't complain about version mismatch