### PR TITLE
Add EVM tutorial

### DIFF
--- a/EVM/README.md
+++ b/EVM/README.md
@@ -1,0 +1,1147 @@
+# Truffle example: EVM
+
+## Table of contents
+
+- [About](#about)
+- [Smart contract](#smart-contract)
+- [Test](#test)
+- [User journey](#user-journey)
+- [Summary](#summary)
+
+## About
+
+This example introduces the use of Acala EVM+ predeployed EVM that is present on every network at a
+fixed address (the address of a predeployed contract is the same on a local development network,
+public test network as well as the production network). As this example focuses on showcasing the
+interactions with the predeployed `EVM`, it doesn't have its own smart conract. We will get all of
+the required imports from the [`@acala-network/contracts`](https://github.com/AcalaNetwork/predeploy-contracts)
+dependency. The precompiles and predeploys are a specific feature of the Acala EVM+, so this
+tutorial is no longer compatible with traditional EVM development networks (like Ganache).
+
+Let's take a look!
+
+## Smart contract
+
+Smart contracts in this tutorial are only used to satisfy the Truffle's requirement to have a smart
+contract to compile. For this, we will create two empty smart contracts that will inherit the `EVM`
+and `Token` from `@acala-network/contracts` dependency. Your skeleton `PrecompiedEVM` smart contract
+should look like this:
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.9;
+
+contract PrecompiledEVM {
+
+}
+```
+
+Import of the `EVM` from `@acala-network/contracts` is done between the `pragma` definition and
+the start od the `contract` block:
+
+```solidity
+import "@acala-network/contracts/evm/EVM.sol";
+```
+
+As we now have access to `EVM.sol` from `@acala-network/contracts`, we can set the inheritance of
+our `PrecompiledEVM` contract:
+
+```solidity
+contract PrecompiledEVM is EVM {
+```
+
+This concludes our `PrecompiledEVM` smart contract.
+
+<details>
+    <summary>Your contracts/PrecompiledEVM.sol should look like this:</summary>
+
+    // SPDX-License-Identifier: MIT
+    pragma solidity =0.8.9;
+
+    import "@acala-network/contracts/evm/EVM.sol";
+
+    contract PrecompiledEVM is EVM {
+        
+    }
+
+</details>
+
+**NOTE: in order for Truffle to properly use the Token precompiles (used in the following section),
+we need to add the [PrecompiledToken.sol](../precompiled-token/README.md/#smart-contract) smart
+contract as well.**
+
+## Test
+
+Tests for this tutorial will validate the expected values returned and expected behaviour of EVM
+predeployed smart contract. The test file in our case is called `EVM.js`. Within it we import the
+`EVM` and `Token` from `@acala-network/contracts` dependency and assign it to `PrecompiledEVM` and
+`PrecompiledToken` variables. The `EVM`, which is the export from the `ADDRESS` utility of
+`@acala-network/contracts` dependency, is imported and it holds the value of the address of the
+predeployed EVM smart contract. We are also importing `truffleAssert` in order to ease our
+verification of the expected values and we are defining the `NULL_ADDRESS` constant, so we don't
+have to copy-paste the value when needed.
+
+The test file with import statements and an empty test should look like this:
+
+```javascript
+const PrecompiledEVM = artifacts.require("@acala-network/contracts/build/contracts/EVM");
+const PrecompiledToken = artifacts.require("@acala-network/contracts/build/contracts/Token");
+
+const truffleAssert = require("truffle-assertions");
+
+const { EVM } = require("@acala-network/contracts/utils/Address");
+const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/*
+ * uncomment accounts to access the test accounts made available by the
+ * Ethereum client
+ * See docs: https://www.trufflesuite.com/docs/truffle/testing/writing-tests-in-javascript
+ */
+contract("PrecompiledEVM", function (accounts) {
+  
+});
+```
+
+To prepare for the testing, we have to define four global variables, `instance`, `contract`,
+`deployer` and `user`. The `instance` will store the predeployed EVM smart contract instance.
+`contract` will store the value of the deployed precompiled token smart contract. The `deployer` and
+`user` will store the accounts that we will be using in our tests. Let's assign them values in the
+`beforeEach` action:
+
+```javascript
+  let instance;
+  let contract;
+  let deployer;
+  let user;
+
+  beforeEach("setup development environment", async function () {
+    [deployer, user] = accounts;
+    instance = await PrecompiledEVM.at(EVM);
+    contract = await PrecompiledToken.new();
+  });
+```
+
+You can see how we used the `EVM` from the `ADDRESS` utility in order to set the address of our
+predeployed smart contract.
+
+Our test will only contain one top-level section called `Operation` in which we will be checking the
+following functions (which will each be tested in its own section):
+
+1. `newContractExtraBytes()` function to get the NewContractExtraBytes constant.
+2. `storageDepositPerByte()` function to get the StorageDepositPerByte constant.
+3. `maintainerOf()` function to get the maintainer of the contract.
+4. `developerDeposit()` function to get the value of the developer deposit.
+5. `publicationFee()` function to get the vale of the publication fee.
+6. `transferMaintainter()` function to transfer the maintainer role of the smart contract.
+7. `publishContract()` function that publishes a smart contract (makes it available for interactions
+to the non-developer accounts).
+8. `developerStatus()` function that returns the development mode status of the address.
+9. `developerDisable()` function that disables developer mode of the account.
+10. `developerEnable()` function that enables developer mode of the account.
+
+The structure described above without the checks, should look like this:
+
+```javascript
+  describe("Operation", function () {
+    describe("newContractExtraBytes()", function () {
+      
+    });
+
+    describe("storageDepositPerByte()", function () {
+      
+    });
+
+    describe("maintainerOf()", function () {
+      
+    });
+
+    describe("developerDeposit()", function () {
+
+    });
+
+    describe("publicationFee()", function () {
+
+    });
+
+    describe("transferMaintainter()", function () {
+
+    });
+
+    describe("publishContract()", function () {
+      
+    });
+
+    describe("developerStatus()", function () {
+      
+    });
+
+    describe("developerDisable()", function () {
+      
+    });
+
+    describe("developerEnable()", function () {
+      
+    });
+  });
+```
+
+When validating the `newContractExtraBytes()` function, we will check for the following examples:
+
+1. New contract extra bytes are returned.
+
+The section should look like this:
+
+```javascript
+      it("should return the new contract extra bytes", async function () {
+        const response = await instance.newContractExtraBytes();
+
+        expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+      });
+```
+
+When validating the `storageDepositPerByte()` function, we will check for the following examples:
+
+1. Storage deposit per byte is returned.
+
+The section should look like this:
+
+```javascript
+      it("should return the storage deposit", async function () {
+        const response = await instance.storageDepositPerByte();
+
+        expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+      });
+```
+
+When validating the `maintainerOf()` function, we will check for the following examples:
+
+1. Maintainer of the contract should be returned
+
+The section should look like this:
+
+```javascript
+      it("should return the developer deposit", async function () {
+        const response = await instance.developerDeposit();
+
+        expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+      });
+```
+
+When validating the `developerDeposit()` function, we will check for the following examples:
+
+1. Value of the developer deposit should be returned.
+
+The section should look like this:
+
+```javascript
+      it("should return the developer deposit", async function () {
+        const response = await instance.developerDeposit();
+
+        expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+      });
+```
+
+When validating the `publicationFee()` function, we will check for the following examples:
+
+1. Publication fee should be returned.
+
+The section should look like this:
+
+```javascript
+      it("should return the publication fee", async function () {
+        const response = await instance.publicationFee();
+
+        expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+      });
+```
+
+When validating the `transferMaintainter()` function, we will check for the following examples:
+
+1. Maintainer of the contract should be transferred if the caller is current maintainer.
+2. `TransferredMaintainer` event should be emitted when the maintainer is transferred.
+3. It should revert if the caller is not the maintainer of the contract.
+4. It should revert if trying to transfer the maintainer of the `0x0`.
+5. It should revert if trying to transfer the maintainer to `0x0` address.
+
+The section should look like this:
+
+```javascript
+      it("should transfer the maintainer of the contract", async function () {
+        const initialOwner = await instance.maintainerOf(contract.address);
+
+        await instance.transferMaintainer(contract.address, user, { from: deployer });
+
+        const finalOwner = await instance.maintainerOf(contract.address);
+
+        expect(initialOwner).to.equal(deployer);
+        expect(finalOwner).to.equal(user);
+      });
+
+      it("should emit TransferredMaintainer when maintainer role of the contract is transferred", async function () {
+        const maintainer = await instance.maintainerOf(contract.address);
+
+        // Maintainer needs to be set to deployer in case any settings from the previous examples
+        // remain. This is because Truffle only executes the beforeEach action before each of the
+        // first-level nested describe blocks, but not the second ones.
+        if(maintainer == user){
+          await instance.transferMaintainer(contract.address, deployer, { from: user });
+        }
+
+        truffleAssert.eventEmitted(
+          await instance.transferMaintainer(contract.address, user, { from: deployer }),
+          "TransferredMaintainer",
+          { contract_address: contract.address, new_maintainer: user }
+        );
+      });
+
+      it("should revert if the caller is not the maintainer of the contract", async function () {
+        const maintainer = await instance.maintainerOf(contract.address);
+
+        // Maintainer needs to be set to deployer in case any settings from the previous examples
+        // remain. This is because Truffle only executes the beforeEach action before each of the
+        // first-level nested describe blocks, but not the second ones.
+        if(maintainer == user){
+          await instance.transferMaintainer(contract.address, deployer, { from: user });
+        }
+
+        await truffleAssert.reverts(
+          instance.transferMaintainer(contract.address, deployer, { from: user })
+        );
+      });
+
+      it("should revert if trying to transfer maintainer of 0x0", async function () {
+        await truffleAssert.reverts(
+          instance.transferMaintainer(NULL_ADDRESS, user, { from: deployer }),
+          "EVM: the contract_address is the zero address"
+        );
+      });
+
+      it("should revert when trying to transfer maintainer to 0x0 address", async function () {
+        await truffleAssert.reverts(
+          instance.transferMaintainer(contract.address, NULL_ADDRESS, { from: deployer }),
+          "EVM: the new_maintainer is the zero address"
+        );
+      });
+```
+
+**NOTE: As the Truffle befoeEach action is only run before the nested describe block, we need to
+make sure that no changes from the previous test examples don't affect the following ones.**
+
+When validating the `publishContract()` function, we will check for the following examples:
+
+1. `ContractPublished` event should be emitted when the contract is published.
+2. It should revert when the caller is not the maintainer of the contract.
+3. It should revert when tring to publish `0x0` contract.
+
+The section should look like this:
+
+```javascript
+      it("should fail when caller is not the maintainer of the contract", async function () {
+        await truffleAssert.fails(instance.publishContract(contract, { from: user }));
+      });
+
+      it("should revert when trying to publish 0x0 contract", async function () {
+        await truffleAssert.reverts(
+          instance.publishContract(NULL_ADDRESS, { from: deployer }),
+          "EVM: the contract_address is the zero address"
+        );
+      });
+
+      it("should emit ContractPublished event", async function () {
+        truffleAssert.eventEmitted(
+          await instance.publishContract(contract.address, { from: deployer }),
+          "ContractPublished",
+          { contract_address: contract.address }
+        );
+      });
+```
+
+When validating the `developerStatus()` function, we will check for the following examples:
+
+1. It should return the developer mode status of the address.
+
+The section should look like this:
+
+```javascript
+      it("should return the status of the development account", async function () {
+        const randomAddress = "0xabcabcabcabcabcabcabcabcabcabcabcabcabca";
+
+        const responseTrue = await instance.developerStatus(deployer);
+        const responseFalse = await instance.developerStatus(randomAddress);
+
+        expect(responseTrue).to.be.true;
+        expect(responseFalse).to.be.false;
+      });
+```
+
+When validating the `developerDisable()` function, we will check for the following examples:
+
+1. It should disable developer mode.
+2. `DeveloperDisabled` event is emitted when developer mode is disabled.
+3. It should revert if developer mode is already disabled.
+
+The section should look like this:
+
+```javascript
+      it("should disable development mode", async function () {
+        const setupStatus = await instance.developerStatus(user);
+
+        if(!setupStatus){
+          await instance.developerEnable({ from: user });
+        }
+
+        const initalStatus = await instance.developerStatus(user);
+
+        await instance.developerDisable({ from: user });
+
+        const finalStatus = await instance.developerStatus(user);
+
+        expect(initalStatus).to.be.true;
+        expect(finalStatus).to.be.false;
+      });
+
+      it("should emit DeveloperDisabled", async function () {
+        const setupStatus = await instance.developerStatus(user);
+
+        if(!setupStatus){
+          await instance.developerEnable({ from: user });
+        }
+
+        truffleAssert.eventEmitted(
+          await instance.developerDisable({ from: user }),
+          "DeveloperDisabled",
+          { account_address: user }
+        );
+      });
+
+      it("should fail if the development account is not enabled", async function () {
+        const setupStatus = await instance.developerStatus(user);
+
+        if(setupStatus){
+          await instance.developerDisable({ from: user });
+        }
+
+        await truffleAssert.fails(instance.developerDisable({ from: user }));
+      });
+```
+
+When validating the `developerEnable()` function, we will check for the following examples:
+
+1. It should enable developer mode.
+2. `DeveloperEnabled` event is emitted when developer mode is enabled.
+3. It should revert if developer mode is already enabled.
+
+The section should look like this:
+
+```javascript
+      it("should enable development mode", async function () {
+        const setupStatus = await instance.developerStatus(user);
+
+        if(setupStatus){
+          await instance.developerDisable({ from: user });
+        }
+
+        const initalStatus = await instance.developerStatus(user);
+
+        await instance.developerEnable({ from: user });
+
+        const finalStatus = await instance.developerStatus(user);
+
+        expect(initalStatus).to.be.false;
+        expect(finalStatus).to.be.true;
+      });
+
+      it("should emit DeveloperEnabled event", async function () {
+        const setupStatus = await instance.developerStatus(user);
+
+        if(setupStatus){
+          await instance.developerDisable({ from: user });
+        }
+
+        truffleAssert.eventEmitted(
+          await instance.developerEnable({ from: user }),
+          "DeveloperEnabled",
+          { account_address: user }
+        );
+      });
+
+      it("should revert if the development mode is already enabled", async function () {
+        const setupStatus = await instance.developerStatus(user);
+
+        if(!setupStatus){
+          await instance.developerEnable({ from: user });
+        }
+
+        await truffleAssert.fails(instance.developerEnable({ from: user }));
+      });
+```
+
+With that, our test is ready to be run.
+
+<details>
+    <summary>Your test/EVM.js should look like this:</summary>
+
+    const PrecompiledEVM = artifacts.require("@acala-network/contracts/build/contracts/EVM");
+    const PrecompiledToken = artifacts.require("@acala-network/contracts/build/contracts/Token");
+
+    const truffleAssert = require("truffle-assertions");
+
+    const { EVM } = require("@acala-network/contracts/utils/Address");
+    const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+    /*
+    * uncomment accounts to access the test accounts made available by the
+    * Ethereum client
+    * See docs: https://www.trufflesuite.com/docs/truffle/testing/writing-tests-in-javascript
+    */
+    contract("PrecompiledEVM", function (accounts) {
+      let instance;
+      let contract;
+      let deployer;
+      let user;
+
+      beforeEach("setup development environment", async function () {
+        [deployer, user] = accounts;
+        instance = await PrecompiledEVM.at(EVM);
+        contract = await PrecompiledToken.new();
+      });
+
+      describe("Operation", function () {
+        describe("newContractExtraBytes()", function () {
+          it("should return the new contract extra bytes", async function () {
+            const response = await instance.newContractExtraBytes();
+
+            expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+          });
+        });
+
+        describe("storageDepositPerByte()", function () {
+          it("should return the storage deposit", async function () {
+            const response = await instance.storageDepositPerByte();
+
+            expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+          });
+        });
+
+        describe("maintainerOf()", function () {
+          it("should return the developer deposit", async function () {
+            const response = await instance.developerDeposit();
+
+            expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+          });
+        });
+
+        describe("developerDeposit()", function () {
+          it("should return the developer deposit", async function () {
+            const response = await instance.developerDeposit();
+
+            expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+          });
+        });
+
+        describe("publicationFee()", function () {
+          it("should return the publication fee", async function () {
+            const response = await instance.publicationFee();
+
+            expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+          });
+        });
+
+        describe("transferMaintainter()", function () {
+          it("should transfer the maintainer of the contract", async function () {
+            const initialOwner = await instance.maintainerOf(contract.address);
+
+            await instance.transferMaintainer(contract.address, user, { from: deployer });
+
+            const finalOwner = await instance.maintainerOf(contract.address);
+
+            expect(initialOwner).to.equal(deployer);
+            expect(finalOwner).to.equal(user);
+          });
+
+          it("should emit TransferredMaintainer when maintainer role of the contract is transferred", async function () {
+            const maintainer = await instance.maintainerOf(contract.address);
+
+            // Maintainer needs to be set to deployer in case any settings from the previous examples
+            // remain. This is because Truffle only executes the beforeEach action before each of the
+            // first-level nested describe blocks, but not the second ones.
+            if(maintainer == user){
+              await instance.transferMaintainer(contract.address, deployer, { from: user });
+            }
+
+            truffleAssert.eventEmitted(
+              await instance.transferMaintainer(contract.address, user, { from: deployer }),
+              "TransferredMaintainer",
+              { contract_address: contract.address, new_maintainer: user }
+            );
+          });
+
+          it("should revert if the caller is not the maintainer of the contract", async function () {
+            const maintainer = await instance.maintainerOf(contract.address);
+
+            // Maintainer needs to be set to deployer in case any settings from the previous examples
+            // remain. This is because Truffle only executes the beforeEach action before each of the
+            // first-level nested describe blocks, but not the second ones.
+            if(maintainer == user){
+              await instance.transferMaintainer(contract.address, deployer, { from: user });
+            }
+
+            await truffleAssert.reverts(
+              instance.transferMaintainer(contract.address, deployer, { from: user })
+            );
+          });
+
+          it("should revert if trying to transfer maintainer of 0x0", async function () {
+            await truffleAssert.reverts(
+              instance.transferMaintainer(NULL_ADDRESS, user, { from: deployer }),
+              "EVM: the contract_address is the zero address"
+            );
+          });
+
+          it("should revert when trying to transfer maintainer to 0x0 address", async function () {
+            await truffleAssert.reverts(
+              instance.transferMaintainer(contract.address, NULL_ADDRESS, { from: deployer }),
+              "EVM: the new_maintainer is the zero address"
+            );
+          });
+        });
+
+        describe("publishContract()", function () {
+          it("should fail when caller is not the maintainer of the contract", async function () {
+            await truffleAssert.fails(instance.publishContract(contract, { from: user }));
+          });
+
+          it("should revert when trying to publish 0x0 contract", async function () {
+            await truffleAssert.reverts(
+              instance.publishContract(NULL_ADDRESS, { from: deployer }),
+              "EVM: the contract_address is the zero address"
+            );
+          });
+
+          it("should emit ContractPublished event", async function () {
+            truffleAssert.eventEmitted(
+              await instance.publishContract(contract.address, { from: deployer }),
+              "ContractPublished",
+              { contract_address: contract.address }
+            );
+          });
+        });
+
+        describe("developerStatus()", function () {
+          it("should return the status of the development account", async function () {
+            const randomAddress = "0xabcabcabcabcabcabcabcabcabcabcabcabcabca";
+
+            const responseTrue = await instance.developerStatus(deployer);
+            const responseFalse = await instance.developerStatus(randomAddress);
+
+            expect(responseTrue).to.be.true;
+            expect(responseFalse).to.be.false;
+          });
+        });
+
+        describe("developerDisable()", function () {
+          it("should disable development mode", async function () {
+            const setupStatus = await instance.developerStatus(user);
+
+            if(!setupStatus){
+              await instance.developerEnable({ from: user });
+            }
+
+            const initalStatus = await instance.developerStatus(user);
+
+            await instance.developerDisable({ from: user });
+
+            const finalStatus = await instance.developerStatus(user);
+
+            expect(initalStatus).to.be.true;
+            expect(finalStatus).to.be.false;
+          });
+
+          it("should emit DeveloperDisabled", async function () {
+            const setupStatus = await instance.developerStatus(user);
+
+            if(!setupStatus){
+              await instance.developerEnable({ from: user });
+            }
+
+            truffleAssert.eventEmitted(
+              await instance.developerDisable({ from: user }),
+              "DeveloperDisabled",
+              { account_address: user }
+            );
+          });
+
+          it("should fail if the development account is not enabled", async function () {
+            const setupStatus = await instance.developerStatus(user);
+
+            if(setupStatus){
+              await instance.developerDisable({ from: user });
+            }
+
+            await truffleAssert.fails(instance.developerDisable({ from: user }));
+          });
+        });
+
+        describe("developerEnable()", function () {
+          it("should enable development mode", async function () {
+            const setupStatus = await instance.developerStatus(user);
+
+            if(setupStatus){
+              await instance.developerDisable({ from: user });
+            }
+
+            const initalStatus = await instance.developerStatus(user);
+
+            await instance.developerEnable({ from: user });
+
+            const finalStatus = await instance.developerStatus(user);
+
+            expect(initalStatus).to.be.false;
+            expect(finalStatus).to.be.true;
+          });
+
+          it("should emit DeveloperEnabled event", async function () {
+            const setupStatus = await instance.developerStatus(user);
+
+            if(setupStatus){
+              await instance.developerDisable({ from: user });
+            }
+
+            truffleAssert.eventEmitted(
+              await instance.developerEnable({ from: user }),
+              "DeveloperEnabled",
+              { account_address: user }
+            );
+          });
+
+          it("should revert if the development mode is already enabled", async function () {
+            const setupStatus = await instance.developerStatus(user);
+
+            if(!setupStatus){
+              await instance.developerEnable({ from: user });
+            }
+
+            await truffleAssert.fails(instance.developerEnable({ from: user }));
+          });
+        });
+      });
+    });
+
+</details>
+
+When you run the test with (for example) `yarn test-mandala`, your tests should pass with the
+following output:
+
+```shell
+yarn test-mandala
+
+
+yarn run v1.22.17
+$ truffle test --network mandala
+Using network 'mandala'.
+
+
+Compiling your contracts...
+===========================
+> Compiling ./../DEX/contracts/PrecompiledDEX.sol
+> Artifacts written to /var/folders/_c/x274s0_x6qj1xtkv60pllc800000gp/T/test--23514-geqKNhJDF16E
+> Compiled successfully using:
+   - solc: 0.8.9+commit.e5eed63a.Emscripten.clang
+
+
+  Contract: PrecompiledEVM
+    Operation
+      newContractExtraBytes()
+        ✓ should return the new contract extra bytes
+      storageDepositPerByte()
+        ✓ should return the storage deposit
+      maintainerOf()
+        ✓ should return the developer deposit
+      developerDeposit()
+        ✓ should return the developer deposit
+      publicationFee()
+        ✓ should return the publication fee
+      transferMaintainter()
+        ✓ should transfer the maintainer of the contract (1204ms)
+        ✓ should emit TransferredMaintainer when maintainer role of the contract is transferred (1186ms)
+        ✓ should revert if the caller is not the maintainer of the contract (88ms)
+        ✓ should revert if trying to transfer maintainer of 0x0 (61ms)
+        ✓ should revert when trying to transfer maintainer to 0x0 address (66ms)
+      publishContract()
+        ✓ should fail when caller is not the maintainer of the contract (248ms)
+        ✓ should revert when trying to publish 0x0 contract (69ms)
+        ✓ should emit ContractPublished event (1162ms)
+      developerStatus()
+        ✓ should return the status of the development account
+      developerDisable()
+        ✓ should disable development mode (1217ms)
+        ✓ should emit DeveloperDisabled (2544ms)
+        ✓ should fail if the development account is not enabled (115ms)
+      developerEnable()
+        ✓ should enable development mode (1301ms)
+        ✓ should emit DeveloperEnabled event (2361ms)
+        ✓ should revert if the development mode is already enabled (98ms)
+
+
+  20 passing (39s)
+
+✨  Done in 45.67s.
+```
+
+## User journey
+
+Since there is no contract to deploy, let's add a simulation of a user interacting with the `EVM`
+and log all of the changes and information ot the console. The script will be called
+`userJourney.js` and will reside in the `scripts/` folder:
+
+```shell
+touch scripts/userJourney.js
+```
+
+The empty user journey script together with the imports of `EVM` from `@acala-network/contracts` and
+precompiled `EVM` and `Token` smart contracts from `@acala-network/contracts` should look like this:
+
+```javascript
+const EVMContract = artifacts.require("@acala-network/contracts/build/contracts/EVM");
+const TokenContract = artifacts.require("@acala-network/contracts/build/contracts/Token");
+
+const { EVM } = require("@acala-network/contracts/utils/Address");
+
+module.exports = async function(callback) {
+  try {
+    
+  }
+  catch(error) {
+    console.log(error)
+  }
+
+  callback()
+}
+```
+
+We will pad the log to the console with empty strings in order to get a more verbose output. At the
+beginning of the script, we assign an address values to `deployer` and `user` and instantiate the
+predeployed `EVM` smart contract with the help of the `ADDRESS` utility:
+
+```javascript
+    console.log("");
+    console.log("");
+
+    const accounts = await web3.eth.getAccounts();
+    const deployer = accounts[0];
+    const user = accounts[1];
+    
+    console.log(`Interacting with EVM using accounts ${deployer} and ${user}`);
+
+    console.log("");
+    console.log("");
+
+    console.log("Instantiating DEX and token smart contracts");
+
+    const instance = await EVMContract.at(EVM);
+
+    console.log("EVM instantiated with address", instance.address);
+```
+
+Now that we have instatiated the smart contract, we have to prepare the accounts for the journey. As
+both start the journey as non-developer accounts, we need to make sure that is the case (and disable
+the development mode if necessary):
+
+```javascript
+    console.log("");
+    console.log("");
+
+    console.log("Preparing addresses for the journey");
+
+    const initalDeployerStatus = await instance.developerStatus(deployer);
+    const initialUserStatus = await instance.developerStatus(user);
+
+    if(initalDeployerStatus){
+      await instance.developerDisable({ from: deployer });
+    }
+
+    if(initialUserStatus){
+      await instance.developerDisable({ from: user });
+    }
+```
+
+As the development mode si disabled on our `deployer` account, we need to enable it. After it is
+enabled, we can query and output the development status of both of the Signers:
+
+```javascript
+    console.log("");
+    console.log("");
+
+    console.log("Enabling development mode on deployer address");
+
+    await instance.developerEnable({ from: deployer });
+
+    const midwayDeployerStatus = await instance.developerStatus(deployer);
+    const midwayUserStatus = await instance.developerStatus(user);
+
+    console.log(`The developer status of ${deployer} in ${midwayDeployerStatus}.`);
+    console.log(`The developer status of ${user} in ${midwayUserStatus}.`);
+```
+
+Now that the `deployer` has developer mode enabled, we can use it to deploy the journey smart
+contract. We can now check for the maintainer of the newly deployed smart contract and output the
+result to the console:
+
+```javascript
+    console.log("");
+    console.log("");
+
+    console.log("Deploying a smart contract");
+
+    const contract = await TokenContract.new();
+
+    const deployMaintainer = await instance.maintainerOf(contract.address);
+
+    console.log(`Contract deployed at ${contract.address} has a maintainer ${deployMaintainer}`);
+```
+
+Before the account, that doesn't have the developer mode enabled can interact with the smart
+contract, the smart contract has to be published. When publishing a smart contract, the maintainer
+has to pay the publication fee. Let's query it, publish the smart contract and log the publication
+fee to the console:
+
+```javascript
+    console.log("");
+    console.log("");
+
+    console.log("Publishing the contract");
+
+    const fee = await instance.publicationFee();
+
+    await instance.publishContract(contract.address, { from: deployer });
+
+    console.log(`Publication fee is ${fee}`);
+    console.log("Contract is sucessfuly published!");
+```
+
+If we wish to transfer maintainer of the smart contract to another address, we need to make sure
+that it has the development mode enabled. Since we will be transferring the maintainer to `user`, we
+have to enable the development mode on it. Once we do, we can output the development mode status of
+both accounts to the console:
+
+```javascript
+    console.log("");
+    console.log("");
+
+    console.log("Enabling developer mode on the user address");
+
+    await instance.developerEnable({ from: user });
+
+    const finalDeployerStatus = await instance.developerStatus(deployer);
+    const finalUserStatus = await instance.developerStatus(user);
+
+    console.log(`The developer status of ${deployer} in ${finalDeployerStatus}.`);
+    console.log(`The developer status of ${user} in ${finalUserStatus}.`);
+```
+
+Now that the `user` Signer is ready to become the maintainer of the journey smart contract, we can
+transfer the maintainer and log the result to the console:
+
+```javascript
+    console.log("");
+    console.log("");
+
+    console.log("Transferring maintainer of the contract to the user address");
+
+    const initialMaintainer = await instance.maintainerOf(contract.address);
+
+    await instance.transferMaintainer(contract.address, user, { from: deployer });
+
+    const finalMaintainer = await instance.maintainerOf(contract.address);
+
+    console.log(`Maintainer of the contract at ${contract.address} was transferred from ${initialMaintainer} to ${finalMaintainer}.`);
+```
+
+Finally our user journey is completed and all that is left to do is to add this information to the
+console:
+
+```javascript
+    console.log("");
+    console.log("");
+
+    console.log("User journey completed!");
+```
+
+This concludes our script.
+
+<details>
+    <summary>Your script/userJourney.js should look like this:</summary>
+
+    const EVMContract = artifacts.require("@acala-network/contracts/build/contracts/EVM");
+    const TokenContract = artifacts.require("@acala-network/contracts/build/contracts/Token");
+
+    const { EVM } = require("@acala-network/contracts/utils/Address");
+
+    module.exports = async function(callback) {
+      try {
+        console.log("");
+        console.log("");
+
+        const accounts = await web3.eth.getAccounts();
+        const deployer = accounts[0];
+        const user = accounts[1];
+        
+        console.log(`Interacting with EVM using accounts ${deployer} and ${user}`);
+
+        console.log("");
+        console.log("");
+
+        console.log("Instantiating DEX and token smart contracts");
+
+        const instance = await EVMContract.at(EVM);
+
+        console.log("EVM instantiated with address", instance.address);
+
+        console.log("");
+        console.log("");
+
+        console.log("Preparing addresses for the journey");
+
+        const initalDeployerStatus = await instance.developerStatus(deployer);
+        const initialUserStatus = await instance.developerStatus(user);
+
+        if(initalDeployerStatus){
+          await instance.developerDisable({ from: deployer });
+        }
+
+        if(initialUserStatus){
+          await instance.developerDisable({ from: user });
+        }
+
+        console.log("");
+        console.log("");
+
+        console.log("Enabling development mode on deployer address");
+
+        await instance.developerEnable({ from: deployer });
+
+        const midwayDeployerStatus = await instance.developerStatus(deployer);
+        const midwayUserStatus = await instance.developerStatus(user);
+
+        console.log(`The developer status of ${deployer} in ${midwayDeployerStatus}.`);
+        console.log(`The developer status of ${user} in ${midwayUserStatus}.`);
+
+        console.log("");
+        console.log("");
+
+        console.log("Deploying a smart contract");
+
+        const contract = await TokenContract.new();
+
+        const deployMaintainer = await instance.maintainerOf(contract.address);
+
+        console.log(`Contract deployed at ${contract.address} has a maintainer ${deployMaintainer}`);
+
+        console.log("");
+        console.log("");
+
+        console.log("Publishing the contract");
+
+        const fee = await instance.publicationFee();
+
+        await instance.publishContract(contract.address, { from: deployer });
+
+        console.log(`Publication fee is ${fee}`);
+        console.log("Contract is sucessfuly published!");
+
+        console.log("");
+        console.log("");
+
+        console.log("Enabling developer mode on the user address");
+
+        await instance.developerEnable({ from: user });
+
+        const finalDeployerStatus = await instance.developerStatus(deployer);
+        const finalUserStatus = await instance.developerStatus(user);
+
+        console.log(`The developer status of ${deployer} in ${finalDeployerStatus}.`);
+        console.log(`The developer status of ${user} in ${finalUserStatus}.`);
+
+        console.log("");
+        console.log("");
+
+        console.log("Transferring maintainer of the contract to the user address");
+
+        const initialMaintainer = await instance.maintainerOf(contract.address);
+
+        await instance.transferMaintainer(contract.address, user, { from: deployer });
+
+        const finalMaintainer = await instance.maintainerOf(contract.address);
+
+        console.log(`Maintainer of the contract at ${contract.address} was transferred from ${initialMaintainer} to ${finalMaintainer}.`);
+
+        console.log("");
+        console.log("");
+
+        console.log("User journey completed!");
+      }
+      catch(error) {
+        console.log(error)
+      }
+
+      callback()
+    }
+
+</details>
+
+Running the `yarn user-journey-mandala` script should return the following output:
+
+```shell
+yarn user-journey-mandala
+
+
+yarn run v1.22.17
+$ truffle exec scripts/userJourney.js --network mandala
+Using network 'mandala'.
+
+
+
+Interacting with EVM using accounts 0x75E480dB528101a381Ce68544611C169Ad7EB342 and 0x0085560b24769dAC4ed057F1B2ae40746AA9aAb6
+
+
+Instantiating DEX and token smart contracts
+EVM instantiated with address 0x0000000000000000000000000000000000000801
+
+
+Preparing addresses for the journey
+
+
+Enabling development mode on deployer address
+The developer status of 0x75E480dB528101a381Ce68544611C169Ad7EB342 in true.
+The developer status of 0x0085560b24769dAC4ed057F1B2ae40746AA9aAb6 in false.
+
+
+Deploying a smart contract
+Contract deployed at 0x8aF989E00782BcB8D837590b88c2968454E7b6aa has a maintainer 0x75E480dB528101a381Ce68544611C169Ad7EB342
+
+
+Publishing the contract
+Publication fee is 1000000000000000000
+Contract is sucessfuly published!
+
+
+Enabling developer mode on the user address
+The developer status of 0x75E480dB528101a381Ce68544611C169Ad7EB342 in true.
+The developer status of 0x0085560b24769dAC4ed057F1B2ae40746AA9aAb6 in true.
+
+
+Transferring maintainer of the contract to the user address
+Maintainer of the contract at 0x8aF989E00782BcB8D837590b88c2968454E7b6aa was transferred from 0x75E480dB528101a381Ce68544611C169Ad7EB342 to 0x0085560b24769dAC4ed057F1B2ae40746AA9aAb6.
+
+
+User journey completed!
+✨  Done in 10.90s.
+```
+
+## Summary
+
+We have built upon the knowledge on how to interact with the Acala EVM+ and gotten familiar with
+Acala EVM+ precompiles and predeploys. To run the test we can use the `yarn test-mandala` and `yarn
+test-madala:pubDev` and to run the user journey script we can use the `yarn user-journey-mandala`
+and `yarn user-journey-mandala:pubDev`. As we are using utilities only available in the Acala EVM+,
+we can no longer use a conventional development network like Ganache.

--- a/EVM/contracts/Migrations.sol
+++ b/EVM/contracts/Migrations.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.22 <0.9.0;
+
+contract Migrations {
+  address public owner = msg.sender;
+  uint public last_completed_migration;
+
+  modifier restricted() {
+    require(
+      msg.sender == owner,
+      "This function is restricted to the contract's owner"
+    );
+    _;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+}

--- a/EVM/contracts/PrecompiledEVM.sol
+++ b/EVM/contracts/PrecompiledEVM.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.9;
+
+import "@acala-network/contracts/evm/EVM.sol";
+
+contract PrecompiledEVM is EVM {
+    
+}

--- a/EVM/contracts/PrecompiledToken.sol
+++ b/EVM/contracts/PrecompiledToken.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.9;
+
+import "@acala-network/contracts/token/Token.sol";
+
+contract PrecompiledToken is Token {
+    
+}

--- a/EVM/migrations/1_initial_migration.js
+++ b/EVM/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+const Migrations = artifacts.require("Migrations");
+
+module.exports = function (deployer) {
+  deployer.deploy(Migrations);
+};

--- a/EVM/package.json
+++ b/EVM/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "truffle-tutorial-evm",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "Jan Turk",
+  "license": "MIT",
+  "dependencies": {
+    "truffle": "^5.4.19"
+  },
+  "devDependencies": {
+    "@acala-network/contracts": "^4.0.0",
+    "@openzeppelin/contracts": "^4.4.1",
+    "@truffle/hdwallet-provider": "^1.6.0",
+    "ethers": "^5.5.3",
+    "truffle-assertions": "^0.9.2"
+  },
+  "scripts": {
+    "build": "truffle compile",
+    "test": "truffle test",
+    "test-mandala": "truffle test --network mandala",
+    "test-mandala:pubDev": "truffle test --network mandalaPublicDev",
+    "test-mandala:CI": "truffle test --network mandalaCI",
+    "user-journey": "truffle exec scripts/userJourney.js",
+    "user-journey-mandala": "truffle exec scripts/userJourney.js --network mandala",
+    "user-journey-mandala:pubDev": "truffle exec scripts/userJourney.js --network mandalaPublicDev",
+    "user-journey-mandala:CI": "truffle exec scripts/userJourney.js --network mandalaCI"
+  }
+}

--- a/EVM/scripts/userJourney.js
+++ b/EVM/scripts/userJourney.js
@@ -1,0 +1,114 @@
+const EVMContract = artifacts.require("@acala-network/contracts/build/contracts/EVM");
+const TokenContract = artifacts.require("@acala-network/contracts/build/contracts/Token");
+
+const { EVM } = require("@acala-network/contracts/utils/Address");
+
+module.exports = async function(callback) {
+  try {
+    console.log("");
+    console.log("");
+
+    const accounts = await web3.eth.getAccounts();
+    const deployer = accounts[0];
+    const user = accounts[1];
+    
+    console.log(`Interacting with EVM using accounts ${deployer} and ${user}`);
+
+    console.log("");
+    console.log("");
+
+    console.log("Instantiating DEX and token smart contracts");
+
+    const instance = await EVMContract.at(EVM);
+
+    console.log("EVM instantiated with address", instance.address);
+
+    console.log("");
+    console.log("");
+
+    console.log("Preparing addresses for the journey");
+
+    const initalDeployerStatus = await instance.developerStatus(deployer);
+    const initialUserStatus = await instance.developerStatus(user);
+
+    if(initalDeployerStatus){
+      await instance.developerDisable({ from: deployer });
+    }
+
+    if(initialUserStatus){
+      await instance.developerDisable({ from: user });
+    }
+
+    console.log("");
+    console.log("");
+
+    console.log("Enabling development mode on deployer address");
+
+    await instance.developerEnable({ from: deployer });
+
+    const midwayDeployerStatus = await instance.developerStatus(deployer);
+    const midwayUserStatus = await instance.developerStatus(user);
+
+    console.log(`The developer status of ${deployer} in ${midwayDeployerStatus}.`);
+    console.log(`The developer status of ${user} in ${midwayUserStatus}.`);
+
+    console.log("");
+    console.log("");
+
+    console.log("Deploying a smart contract");
+
+    const contract = await TokenContract.new();
+
+    const deployMaintainer = await instance.maintainerOf(contract.address);
+
+    console.log(`Contract deployed at ${contract.address} has a maintainer ${deployMaintainer}`);
+
+    console.log("");
+    console.log("");
+
+    console.log("Publishing the contract");
+
+    const fee = await instance.publicationFee();
+
+    await instance.publishContract(contract.address, { from: deployer });
+
+    console.log(`Publication fee is ${fee}`);
+    console.log("Contract is sucessfuly published!");
+
+    console.log("");
+    console.log("");
+
+    console.log("Enabling developer mode on the user address");
+
+    await instance.developerEnable({ from: user });
+
+    const finalDeployerStatus = await instance.developerStatus(deployer);
+    const finalUserStatus = await instance.developerStatus(user);
+
+    console.log(`The developer status of ${deployer} in ${finalDeployerStatus}.`);
+    console.log(`The developer status of ${user} in ${finalUserStatus}.`);
+
+    console.log("");
+    console.log("");
+
+    console.log("Transferring maintainer of the contract to the user address");
+
+    const initialMaintainer = await instance.maintainerOf(contract.address);
+
+    await instance.transferMaintainer(contract.address, user, { from: deployer });
+
+    const finalMaintainer = await instance.maintainerOf(contract.address);
+
+    console.log(`Maintainer of the contract at ${contract.address} was transferred from ${initialMaintainer} to ${finalMaintainer}.`);
+
+    console.log("");
+    console.log("");
+
+    console.log("User journey completed!");
+  }
+  catch(error) {
+    console.log(error)
+  }
+
+  callback()
+}

--- a/EVM/test/EVM.js
+++ b/EVM/test/EVM.js
@@ -1,0 +1,245 @@
+const PrecompiledEVM = artifacts.require("@acala-network/contracts/build/contracts/EVM");
+const PrecompiledToken = artifacts.require("@acala-network/contracts/build/contracts/Token");
+
+const truffleAssert = require("truffle-assertions");
+
+const { EVM } = require("@acala-network/contracts/utils/Address");
+const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/*
+ * uncomment accounts to access the test accounts made available by the
+ * Ethereum client
+ * See docs: https://www.trufflesuite.com/docs/truffle/testing/writing-tests-in-javascript
+ */
+contract("PrecompiledEVM", function (accounts) {
+  let instance;
+  let contract;
+  let deployer;
+  let user;
+
+  beforeEach("setup development environment", async function () {
+    [deployer, user] = accounts;
+    instance = await PrecompiledEVM.at(EVM);
+    contract = await PrecompiledToken.new();
+  });
+
+  describe("Operation", function () {
+    describe("newContractExtraBytes()", function () {
+      it("should return the new contract extra bytes", async function () {
+        const response = await instance.newContractExtraBytes();
+
+        expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+      });
+    });
+
+    describe("storageDepositPerByte()", function () {
+      it("should return the storage deposit", async function () {
+        const response = await instance.storageDepositPerByte();
+
+        expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+      });
+    });
+
+    describe("maintainerOf()", function () {
+      it("should return the developer deposit", async function () {
+        const response = await instance.developerDeposit();
+
+        expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+      });
+    });
+
+    describe("developerDeposit()", function () {
+      it("should return the developer deposit", async function () {
+        const response = await instance.developerDeposit();
+
+        expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+      });
+    });
+
+    describe("publicationFee()", function () {
+      it("should return the publication fee", async function () {
+        const response = await instance.publicationFee();
+
+        expect(response.gt(web3.utils.toBN("0"))).to.be.true;
+      });
+    });
+
+    describe("transferMaintainter()", function () {
+      it("should transfer the maintainer of the contract", async function () {
+        const initialOwner = await instance.maintainerOf(contract.address);
+
+        await instance.transferMaintainer(contract.address, user, { from: deployer });
+
+        const finalOwner = await instance.maintainerOf(contract.address);
+
+        expect(initialOwner).to.equal(deployer);
+        expect(finalOwner).to.equal(user);
+      });
+
+      it("should emit TransferredMaintainer when maintainer role of the contract is transferred", async function () {
+        const maintainer = await instance.maintainerOf(contract.address);
+
+        // Maintainer needs to be set to deployer in case any settings from the previous examples
+        // remain. This is because Truffle only executes the beforeEach action before each of the
+        // first-level nested describe blocks, but not the second ones.
+        if(maintainer == user){
+          await instance.transferMaintainer(contract.address, deployer, { from: user });
+        }
+
+        truffleAssert.eventEmitted(
+          await instance.transferMaintainer(contract.address, user, { from: deployer }),
+          "TransferredMaintainer",
+          { contract_address: contract.address, new_maintainer: user }
+        );
+      });
+
+      it("should revert if the caller is not the maintainer of the contract", async function () {
+        const maintainer = await instance.maintainerOf(contract.address);
+
+        // Maintainer needs to be set to deployer in case any settings from the previous examples
+        // remain. This is because Truffle only executes the beforeEach action before each of the
+        // first-level nested describe blocks, but not the second ones.
+        if(maintainer == user){
+          await instance.transferMaintainer(contract.address, deployer, { from: user });
+        }
+
+        await truffleAssert.reverts(
+          instance.transferMaintainer(contract.address, deployer, { from: user })
+        );
+      });
+
+      it("should revert if trying to transfer maintainer of 0x0", async function () {
+        await truffleAssert.reverts(
+          instance.transferMaintainer(NULL_ADDRESS, user, { from: deployer }),
+          "EVM: the contract_address is the zero address"
+        );
+      });
+
+      it("should revert when trying to transfer maintainer to 0x0 address", async function () {
+        await truffleAssert.reverts(
+          instance.transferMaintainer(contract.address, NULL_ADDRESS, { from: deployer }),
+          "EVM: the new_maintainer is the zero address"
+        );
+      });
+    });
+
+    describe("publishContract()", function () {
+      it("should fail when caller is not the maintainer of the contract", async function () {
+        await truffleAssert.fails(instance.publishContract(contract, { from: user }));
+      });
+
+      it("should revert when trying to publish 0x0 contract", async function () {
+        await truffleAssert.reverts(
+          instance.publishContract(NULL_ADDRESS, { from: deployer }),
+          "EVM: the contract_address is the zero address"
+        );
+      });
+
+      it("should emit ContractPublished event", async function () {
+        truffleAssert.eventEmitted(
+          await instance.publishContract(contract.address, { from: deployer }),
+          "ContractPublished",
+          { contract_address: contract.address }
+        );
+      });
+    });
+
+    describe("developerStatus()", function () {
+      it("should return the status of the development account", async function () {
+        const randomAddress = "0xabcabcabcabcabcabcabcabcabcabcabcabcabca";
+
+        const responseTrue = await instance.developerStatus(deployer);
+        const responseFalse = await instance.developerStatus(randomAddress);
+
+        expect(responseTrue).to.be.true;
+        expect(responseFalse).to.be.false;
+      });
+    });
+
+    describe("developerDisable()", function () {
+      it("should disable development mode", async function () {
+        const setupStatus = await instance.developerStatus(user);
+
+        if(!setupStatus){
+          await instance.developerEnable({ from: user });
+        }
+
+        const initalStatus = await instance.developerStatus(user);
+
+        await instance.developerDisable({ from: user });
+
+        const finalStatus = await instance.developerStatus(user);
+
+        expect(initalStatus).to.be.true;
+        expect(finalStatus).to.be.false;
+      });
+
+      it("should emit DeveloperDisabled", async function () {
+        const setupStatus = await instance.developerStatus(user);
+
+        if(!setupStatus){
+          await instance.developerEnable({ from: user });
+        }
+
+        truffleAssert.eventEmitted(
+          await instance.developerDisable({ from: user }),
+          "DeveloperDisabled",
+          { account_address: user }
+        );
+      });
+
+      it("should fail if the development account is not enabled", async function () {
+        const setupStatus = await instance.developerStatus(user);
+
+        if(setupStatus){
+          await instance.developerDisable({ from: user });
+        }
+
+        await truffleAssert.fails(instance.developerDisable({ from: user }));
+      });
+    });
+
+    describe("developerEnable()", function () {
+      it("should enable development mode", async function () {
+        const setupStatus = await instance.developerStatus(user);
+
+        if(setupStatus){
+          await instance.developerDisable({ from: user });
+        }
+
+        const initalStatus = await instance.developerStatus(user);
+
+        await instance.developerEnable({ from: user });
+
+        const finalStatus = await instance.developerStatus(user);
+
+        expect(initalStatus).to.be.false;
+        expect(finalStatus).to.be.true;
+      });
+
+      it("should emit DeveloperEnabled event", async function () {
+        const setupStatus = await instance.developerStatus(user);
+
+        if(setupStatus){
+          await instance.developerDisable({ from: user });
+        }
+
+        truffleAssert.eventEmitted(
+          await instance.developerEnable({ from: user }),
+          "DeveloperEnabled",
+          { account_address: user }
+        );
+      });
+
+      it("should revert if the development mode is already enabled", async function () {
+        const setupStatus = await instance.developerStatus(user);
+
+        if(!setupStatus){
+          await instance.developerEnable({ from: user });
+        }
+
+        await truffleAssert.fails(instance.developerEnable({ from: user }));
+      });
+    });
+  });
+});

--- a/EVM/truffle-config.js
+++ b/EVM/truffle-config.js
@@ -1,0 +1,119 @@
+/**
+ * Use this file to configure your truffle project. It's seeded with some
+ * common settings for different networks and features like migrations,
+ * compilation and testing. Uncomment the ones you need or modify
+ * them to suit your project as necessary.
+ *
+ * More information about configuration can be found at:
+ *
+ * trufflesuite.com/docs/advanced/configuration
+ *
+ * To deploy via Infura you'll need a wallet provider (like @truffle/hdwallet-provider)
+ * to sign your transactions before they're sent to a remote public node. Infura accounts
+ * are available for free at: infura.io/register.
+ *
+ * You'll also need a mnemonic - the twelve word phrase the wallet uses to generate
+ * public/private key pairs. If you're publishing your code to GitHub make sure you load this
+ * phrase from a file you've .gitignored so it doesn't accidentally become public.
+ *
+ */
+
+const HDWalletProvider = require('@truffle/hdwallet-provider');
+//
+// const fs = require('fs');
+// const mnemonic = fs.readFileSync(".secret").toString().trim();
+const mnemonicPhrase = 'fox sight canyon orphan hotel grow hedgehog build bless august weather swarm';
+
+const mandalaConfig = (endpointUrl) => ({
+  provider: () =>
+    new HDWalletProvider(mnemonicPhrase, endpointUrl),
+  network_id: 595,
+  gasPrice: 200786445289, // storage_limit = 64001, validUntil = 360001, gasLimit = 10000000
+  gas: 42032000,
+  timeoutBlocks: 25,
+  confirmations: 0
+});
+
+module.exports = {
+  /**
+   * Networks define how you connect to your ethereum client and let you set the
+   * defaults web3 uses to send transactions. If you don't specify one truffle
+   * will spin up a development blockchain for you on port 9545 when you
+   * run `develop` or `test`. You can ask a truffle command to use a specific
+   * network from the command line, e.g
+   *
+   * $ truffle test --network <network-name>
+   */
+
+  networks: {
+    mandala: mandalaConfig("http://127.0.0.1:8545"),
+    mandalaPublicDev: mandalaConfig("https://tc7-eth.aca-dev.network"),
+    mandalaCI: mandalaConfig("http://eth-rpc-adapter-server:8545"),
+    // Useful for testing. The `development` name is special - truffle uses it by default
+    // if it's defined here and no other network is specified at the command line.
+    // You should run a client (like ganache-cli, geth or parity) in a separate terminal
+    // tab if you use this network and you must also set the `host`, `port` and `network_id`
+    // options below to some value.
+    //
+    development: {
+     host: "127.0.0.1",     // Localhost (default: none)
+     port: 8545,            // Standard Ethereum port (default: none)
+     network_id: "*",       // Any network (default: none)
+    },
+    // Another network with more advanced options...
+    // advanced: {
+    // port: 8777,             // Custom port
+    // network_id: 1342,       // Custom network
+    // gas: 8500000,           // Gas sent with each transaction (default: ~6700000)
+    // gasPrice: 20000000000,  // 20 gwei (in wei) (default: 100 gwei)
+    // from: <address>,        // Account to send txs from (default: accounts[0])
+    // websocket: true        // Enable EventEmitter interface for web3 (default: false)
+    // },
+    // Useful for deploying to a public network.
+    // NB: It's important to wrap the provider as a function.
+    // ropsten: {
+    // provider: () => new HDWalletProvider(mnemonic, `https://ropsten.infura.io/v3/YOUR-PROJECT-ID`),
+    // network_id: 3,       // Ropsten's id
+    // gas: 5500000,        // Ropsten has a lower block limit than mainnet
+    // confirmations: 2,    // # of confs to wait between deployments. (default: 0)
+    // timeoutBlocks: 200,  // # of blocks before a deployment times out  (minimum/default: 50)
+    // skipDryRun: true     // Skip dry run before migrations? (default: false for public nets )
+    // },
+    // Useful for private networks
+    // private: {
+    // provider: () => new HDWalletProvider(mnemonic, `https://network.io`),
+    // network_id: 2111,   // This network is yours, in the cloud.
+    // production: true    // Treats this network as if it was a public net. (default: false)
+    // }
+  },
+
+  // Set default mocha options here, use special reporters etc.
+  mocha: {
+    timeout: 100000
+  },
+
+  // Configure your compilers
+  compilers: {
+    solc: {
+      version: "0.8.9",    // Fetch exact version from solc-bin (default: truffle's version)
+      // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
+      // settings: {          // See the solidity docs for advice about optimization and evmVersion
+      //  optimizer: {
+      //    enabled: false,
+      //    runs: 200
+      //  },
+      //  evmVersion: "byzantium"
+      // }
+    }
+  },
+
+  // Truffle DB is currently disabled by default; to enable it, change enabled: false to enabled: true
+  //
+  // Note: if you migrated your contracts prior to enabling this field in your Truffle project and want
+  // those previously migrated contracts available in the .db directory, you will need to run the following:
+  // $ truffle migrate --reset --compile-all
+
+  db: {
+    enabled: false
+  }
+};

--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ for them in the documentation and hardcode them into our project.
 6. [DEX](./DEX/README.md): This tutorial utilizes the predeployed `DEX` smart contract to swap the
 ERC20 tokens of the  predeployed `Token` smart contracts, which we instantiate with the help of the
 `ADDRESS` utility.
+
+7. [EVM](./EVM/README.md): This tutorial utilizes the predeployed `EVM` smart contract to manage the
+account preferences and the smart contract that the account maintains. It introduces the publishing
+of the smart contracts in the Acala EVM+ as well as enabling and disabling the developer mode of the
+account directly in the Acala EVM+.

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,8 @@ build_all() {
     -t truffle-tutorial-token \
     -t truffle-tutorial-nft \
     -t truffle-tutorial-precompiled-token \
-    -t truffle-tutorial-dex'
+    -t truffle-tutorial-dex \
+    -t truffle-tutorial-evm'
 }
 
 rebuild_all() {
@@ -19,7 +20,8 @@ rebuild_all() {
     -t truffle-tutorial-token \
     -t truffle-tutorial-nft \
     -t truffle-tutorial-precompiled-token \
-    -t truffle-tutorial-dex'
+    -t truffle-tutorial-dex \
+    -t truffle-tutorial-evm'
 }
 
 test_all() {
@@ -30,6 +32,7 @@ test_all() {
     "NFT"
     "precompiled-token"
     "DEX"
+    "EVM"
   )
 
   ROOT=$(pwd)


### PR DESCRIPTION
This tutorial utilizes the predeployed EVM smart contract to manage
the account preferences and the smart contract that the account
maintains. It introduces the publishing of the smart contracts in the
Acala EVM+ as well as enabling and disabling the developer mode of the
account directly in the Acala EVM+.