### PR TITLE
Update Mandala RPC endpoint

### DIFF
--- a/DEX/truffle-config.js
+++ b/DEX/truffle-config.js
@@ -46,7 +46,7 @@ module.exports = {
 
   networks: {
     mandala: mandalaConfig('http://127.0.0.1:8545'),
-    mandalaPublicDev: mandalaConfig('https://tc7-eth.aca-dev.network'),
+    mandalaPublicDev: mandalaConfig('http://mandala-eth-rpc-adapter.thechaindata.com/public'),
     mandalaCI: mandalaConfig('http://eth-rpc-adapter-server:8545'),
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.

--- a/EVM/truffle-config.js
+++ b/EVM/truffle-config.js
@@ -46,7 +46,7 @@ module.exports = {
 
   networks: {
     mandala: mandalaConfig('http://127.0.0.1:8545'),
-    mandalaPublicDev: mandalaConfig('https://tc7-eth.aca-dev.network'),
+    mandalaPublicDev: mandalaConfig('http://mandala-eth-rpc-adapter.thechaindata.com/public'),
     mandalaCI: mandalaConfig('http://eth-rpc-adapter-server:8545'),
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.

--- a/NFT/truffle-config.js
+++ b/NFT/truffle-config.js
@@ -46,7 +46,7 @@ module.exports = {
 
   networks: {
     mandala: mandalaConfig('http://127.0.0.1:8545'),
-    mandalaPublicDev: mandalaConfig('https://tc7-eth.aca-dev.network'),
+    mandalaPublicDev: mandalaConfig('http://mandala-eth-rpc-adapter.thechaindata.com/public'),
     mandalaCI: mandalaConfig('http://eth-rpc-adapter-server:8545'),
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.

--- a/advanced-escrow/README.md
+++ b/advanced-escrow/README.md
@@ -119,7 +119,7 @@ pasting the following two lines of code into it:
 
 ```js
     mandala: mandalaConfig("http://127.0.0.1:8545"),
-    mandalaPublicDev: mandalaConfig("https://tc7-eth.aca-dev.network"),
+    mandalaPublicDev: mandalaConfig("http://mandala-eth-rpc-adapter.thechaindata.com/public"),
 ```
 
 Now that Mandala local development network is added to our project, let's take care of the remaining

--- a/advanced-escrow/truffle-config.js
+++ b/advanced-escrow/truffle-config.js
@@ -46,7 +46,7 @@ module.exports = {
 
   networks: {
     mandala: mandalaConfig('http://127.0.0.1:8545'),
-    mandalaPublicDev: mandalaConfig('https://tc7-eth.aca-dev.network'),
+    mandalaPublicDev: mandalaConfig('http://mandala-eth-rpc-adapter.thechaindata.com/public'),
     mandalaCI: mandalaConfig('http://eth-rpc-adapter-server:8545'),
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.

--- a/echo/truffle-config.js
+++ b/echo/truffle-config.js
@@ -46,7 +46,7 @@ module.exports = {
 
   networks: {
     mandala: mandalaConfig('http://127.0.0.1:8545'),
-    mandalaPublicDev: mandalaConfig('https://tc7-eth.aca-dev.network'),
+    mandalaPublicDev: mandalaConfig('http://mandala-eth-rpc-adapter.thechaindata.com/public'),
     mandalaCI: mandalaConfig('http://eth-rpc-adapter-server:8545'),
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -126,7 +126,7 @@ pasting the following two lines of code into it:
 
 ```js
     mandala: mandalaConfig("http://127.0.0.1:8545"),
-    mandalaPublicDev: mandalaConfig("https://tc7-eth.aca-dev.network"),
+    mandalaPublicDev: mandalaConfig("http://mandala-eth-rpc-adapter.thechaindata.com/public"),
 ```
 
 Now that Mandala local development network is added to our project, let's take care of the remaining

--- a/hello-world/truffle-config.js
+++ b/hello-world/truffle-config.js
@@ -46,7 +46,7 @@ module.exports = {
 
   networks: {
     mandala: mandalaConfig('http://127.0.0.1:8545'),
-    mandalaPublicDev: mandalaConfig('https://tc7-eth.aca-dev.network'),
+    mandalaPublicDev: mandalaConfig('http://mandala-eth-rpc-adapter.thechaindata.com/public'),
     mandalaCI: mandalaConfig('http://eth-rpc-adapter-server:8545'),
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.

--- a/precompiled-token/truffle-config.js
+++ b/precompiled-token/truffle-config.js
@@ -46,7 +46,7 @@ module.exports = {
 
   networks: {
     mandala: mandalaConfig('http://127.0.0.1:8545'),
-    mandalaPublicDev: mandalaConfig('https://tc7-eth.aca-dev.network'),
+    mandalaPublicDev: mandalaConfig('http://mandala-eth-rpc-adapter.thechaindata.com/public'),
     mandalaCI: mandalaConfig('http://eth-rpc-adapter-server:8545'),
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.

--- a/token/truffle-config.js
+++ b/token/truffle-config.js
@@ -46,7 +46,7 @@ module.exports = {
 
   networks: {
     mandala: mandalaConfig('http://127.0.0.1:8545'),
-    mandalaPublicDev: mandalaConfig('https://tc7-eth.aca-dev.network'),
+    mandalaPublicDev: mandalaConfig('http://mandala-eth-rpc-adapter.thechaindata.com/public'),
     mandalaCI: mandalaConfig('http://eth-rpc-adapter-server:8545'),
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.


### PR DESCRIPTION
Mandala RPC endpoint has been updated to use the Onfinality public RPC endpoint. This should provide more stability when interacting with Mandala using the examples.